### PR TITLE
Remove paste command

### DIFF
--- a/rec_radiko_ts.sh
+++ b/rec_radiko_ts.sh
@@ -282,7 +282,7 @@ show_all_stations() {
   # Format to "{id}:{name}"
   curl --silent 'https://radiko.jp/v3/station/region/full.xml' \
     | xmllint --xpath '/region/stations/station[timefree="1"]/id/text() | /region/stations/station[timefree="1"]/name/text() | /region/stations/station[timefree="1"]/tf_max_delay/text()' - \
-    | paste -d ':' - - -
+    | awk 'ORS=NR%3?":":"\n"'
 }
 
 #######################################


### PR DESCRIPTION
現在の Radiko の当該 XML 構造においては、すべての `<station>` 要素が `<id>`, `<name>`, `<tf_max_delay>` の 3 つの子要素を必ず含んでいるため、いま `paste` で行っている処理は本変更によって代替可能です。
paste コマンドは本スクリプト内でこの 1 箇所でしか使用されておらず、awk に置き換えることで paste への依存を排除しつつ、常用されている `awk` へ統一することができます。

Linux（ネイティブシェル）上で実行し、`-l` オプションのコンソール出力内容が完全に一致していることは当方環境で確認済です。

本 pull request は当方の fork におけるコマンド依存を除去していく過程で修正したものの展開に過ぎず、こちらのプロジェクトで `paste` を除去する意義を感じられないようでしたらこのマージ案は棄却していただいて構いません。